### PR TITLE
Typo in MRIAcquisition.schema.tpl.json

### DIFF
--- a/schemas/activity/MRIAcquisition.schema.tpl.json
+++ b/schemas/activity/MRIAcquisition.schema.tpl.json
@@ -1,5 +1,5 @@
 {
-  "_extends": "/core/schemas/research/ExperimentalActivity.schema.tpl.json",
+  "_extends": "/core/schemas/research/experimentalActivity.schema.tpl.json",
   "properties": {
     "contrastAgent": {
       "_instruction": "Add the contrast agent used for this scan.",


### PR DESCRIPTION
A typo in the _extends property of MRIAcquisition prevents it from being extended correctly.