### PR TITLE
Updated version of MRIScannerUsage for v5

### DIFF
--- a/.github/workflows/openMINDS_upstream.yml
+++ b/.github/workflows/openMINDS_upstream.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - name: Trigger central repository
       run: |
-        curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/openMetadataInitiative/openMINDS/actions/workflows/build.yml/dispatches --data '{"ref": "pipeline", "inputs": {"branch": "${{github.ref_name}}", "repository": "${{ github.repository }}"}'
+        curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/openMetadataInitiative/openMINDS/actions/workflows/build-dev.yml/dispatches --data '{"ref": "pipeline", "inputs": {"branch": "${{github.ref_name}}", "repository": "${{ github.repository }}"}'

--- a/.github/workflows/openMINDS_upstream.yml
+++ b/.github/workflows/openMINDS_upstream.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - name: Trigger central repository
       run: |
-        curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/openMetadataInitiative/openMINDS/actions/workflows/build-dev.yml/dispatches --data '{"ref": "pipeline", "inputs": {"branch": "${{github.ref_name}}", "repository": "${{ github.repository }}"}'
+        curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/openMetadataInitiative/openMINDS/actions/workflows/build-dev.yml/dispatches --data '{"ref": "pipeline", "inputs": {"branch": "${{github.ref_name}}", "repository": "${{ github.repository }}"}}'

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -153,7 +153,7 @@
       ]
     },
     "transmitterBandwidth": {
-      "_instruction": "Enter the transmit bandwidth corresponding to range of frequencies excited by the radiofrequency pulse to image a specific slice (Hz/pixel).",
+      "_instruction": "Enter the transmitter bandwidth, defined as the frequency range excited by the radiofrequency pulse per pixel, expressed in hertz per pixel. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -55,7 +55,7 @@
       ]
     },
     "gradientCorrection": {
-      "_instruction": "Enter the method used for gradient correction",
+      "_instruction": "Add the gradient correction method applied during image reconstruction. This information is typically defined by the scanner system and can be retrieved from the reconstruction settings or DICOM header.",
       "type": "controlledTerms:AnalysisTechnique" 
     },
     "inversionTime": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -120,6 +120,15 @@
         "core:QuantitativeValue"
       ]
     },
+    "sliceAngulation": {
+      "_instruction": "Enter the slice plane orientation as a three-element unit normal vector [nx, ny, nz] in scanner coordinates, where each component is a dimensionless floating-point value between -1 and +1 and the vector has unit length (nx² + ny² + nz² = 1). For non-oblique acquisitions, the vector aligns with a principal axis (for example, [0, 0, 1]), and for oblique acquisitions, the components are fractional.",
+      "items": {
+        "type": "float"
+      },
+      "maxItems": 3,
+      "minItems": 3,
+      "type": "array"
+    },
     "sliceGap": {
       "_instruction": "Enter the slice gap, defined as the distance between adjacent slices, expressed in millimeters and excluding the slice thickness; if slice spacing is uniform, provide a single value, and if it varies across the volume, provide the corresponding range. This information is specified in the acquisition protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -63,12 +63,6 @@
       ],
       "_instruction": "Enter the inversion time of this aquistion."
     },
-    "spatialEncoding": {
-      "_instruction": "Add how spatial information was encoded. Examples include 'frequencyPhaseEncoding' (2D) and 'frequencyPhasePhaseEncoding' (3D).",
-      "_linkedTypes": [
-        "controlledTerms:SpatialEncoding"
-      ]
-    },
     "MRIWeighting": {
       "_instruction": "Add MRI weighting type (e.g.T1Weighting, T2Weighting, R2Weighting, PDWeighting). Note: these terms are not standadized, they merely communicate the image contrast is dominated by the chosen tissue parameter",
       "_linkedTypes": [
@@ -106,6 +100,12 @@
       "_instruction": "Enter the time in which each slice have been acquired within each volume, relative to the beginning of the volume acquisition.",
       "_linkedTypes": [
         "core:QuantitativeValueArray"
+      ]
+    },
+    "spatialEncoding": {
+      "_instruction": "Add how spatial information was encoded. Examples include 'frequencyPhaseEncoding' (2D) and 'frequencyPhasePhaseEncoding' (3D).",
+      "_linkedTypes": [
+        "controlledTerms:SpatialEncoding"
       ]
     },
     "spoilingType": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -159,7 +159,7 @@
       ]
     },
     "totalReadOutTime": {
-      "_instruction": "Enter the total readout time (TRT) as the time interval between acquisition of the first and last k-space lines in the phase-encoding direction during the echo-planar imaging readout.",
+      "_instruction": "Enter the total readout time (TRT), defined as the time interval between acquisition of the first and last k-space lines in the phase-encoding direction during a single readout, expressed in milliseconds. This value is typically computed automatically and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -48,7 +48,7 @@
     },
     "gradientCorrection": {
       "_instruction": "Enter the method used for gradient correction",
-      "type": "controlledTerms:GradientCorrection:" 
+      "type": "controlledTerms:AnalysisTechnique" 
     },
     "interSliceGap": {
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -169,7 +169,9 @@
       "_linkedTypes": [
         "controlledTerms:DeviceType",
         "neuroimaging:MRICoilUsage"
-      ]
+      ],
+      "minItems": 2,
+      "type" : "array"
     },
     "voxelSize": {
       "_instruction": "Enter the voxel size as the physical dimensions of a single image voxel in the x, y, and z directions, expressed in millimeters. This value is typically derived from the field of view, matrix size, and slice thickness and can be retrieved from the DICOM header.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -1,7 +1,7 @@
 {
   "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "_type": "neuroimaging:MRIScannerUsage",
-      "required": [
+  "required": [
     "echoTime",
     "repetitionTime",
     "sliceTiming"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -7,17 +7,14 @@
     "sliceTiming"
   ],
   "properties": {
-    "bValues": {
-      "_instruction": "Add the b values coresponding to this acquisition.",
+    "diffusionEncodingParameters": {
+      "_instruction": "Enter two files corresponding to b-values and b-vectors parameters used to generate diffusion images.",
       "_linkedTypes": [
         "core:File"
-      ]
-    },
-    "bVectors": {
-      "_instruction": "Add the b vectors coresponding to this acquisition.",
-      "_linkedTypes": [
-        "core:File"
-      ]
+      ],
+      "minItems": 2, 
+      "maxItems": 2,
+      "type" : "array"
     },
     "dwellTime": {
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -41,6 +41,10 @@
       ],
       "_instruction": "Enter the flip angle of this scan (preferred units: degrees)."
     },
+    "GradientCorrection": {
+      "_instruction": "Enter the method used for gradient correction",
+      "type": "controlledTerms:GradientCorrection:" 
+    },
     "interSliceGap": {
       "_embeddedTypes": [
         "core:QuantitativeValue",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -114,6 +114,12 @@
         "controlledTerms:MRISpoilingType"
       ]
     },
+    "totalReadOutTime": {
+      "_instruction": "Enter the total readout time (TRT) as the time interval between acquisition of the first and last k-space lines in the phase-encoding direction during the echo-planar imaging readout.",
+      "_embeddedTypes": [
+        "core:QuantitativeValue"
+      ]
+    },
     "usedCoils": {
       "_instruction": "Add the radiofrequency coils used for this experiment. Corresponds to DICOM tags (0018,9042) [MR Receive Coil Sequence Attribute] and (0018,9049) [MR Transmit Coil Sequence Attribute]. Preferably, create an object describing the coil (e.g., an instance of neuroimaging:MRIRadiofrequencyCoil); if less information is available, provide at least the device type.",
       "_linkedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -7,6 +7,10 @@
     "sliceTiming"
   ],
   "properties": {
+    "accelerationFactor": {
+      "_instruction": "Enter the acceleration factor (R) corresponding to reduce number of phase-encoding steps, preferably defined between 2 and 6 .",
+      "type": "integer"
+    },
     "diffusionEncodingParameters": {
       "_instruction": "Enter two files corresponding to b-values and b-vectors parameters used to generate diffusion images.",
       "_linkedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -115,7 +115,7 @@
       ]
     },
     "repetitionTime": {
-      "_instruction": "Enter the echo time of this acquisition (TR).",
+      "_instruction": "Enter the repetition time (TR), defined as the interval between successive excitation pulses, expressed in milliseconds. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -28,7 +28,7 @@
       ]
     },
     "echoTime": {
-      "_instruction": "Enter the echo times of this acquisition (TE).",
+      "_instruction": "Enter the echo time (TE), defined as the interval between the center of the excitation pulse and the center of the measured echo, expressed in milliseconds. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ],

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -123,7 +123,7 @@
     "sliceAngulation": {
       "_instruction": "Enter the slice plane orientation as a three-element unit normal vector [nx, ny, nz] in scanner coordinates, where each component is a dimensionless floating-point value between -1 and +1 and the vector has unit length (nx² + ny² + nz² = 1). For non-oblique acquisitions, the vector aligns with a principal axis (for example, [0, 0, 1]), and for oblique acquisitions, the components are fractional.",
       "items": {
-        "type": "float"
+        "type": "number"
       },
       "maxItems": 3,
       "minItems": 3,

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -75,7 +75,7 @@
         "controlledTerms:MRIWeighting"
       ]
     },
-    "MagnetizationTransferPulseShape": {
+    "magnetizationTransferPulseShape": {
       "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
       "type": "controlledTerms:PulseShape"
     },
@@ -88,10 +88,19 @@
       "type": "controlledTerms:MRIparallelAcquisitionTechnique"
     },
     "phaseEncodingDirection": {
+      "_instruction": "Enter the phase encoding direction as a signed unit vector in the scanner or image coordinate system (e.g., [+/-1, 0, 0], [0, +/-1, 0], or [0, 0, +/-1]), where the single nonzero component indicates the x, y, or z axis of phase encoding and the sign indicates the polarity of k-space traversal.",
+      "items": {
+        "type": "integer"
+      },
+      "maxItems": 3,
+      "minItems": 3,
+      "type": "array"
+    },
+    "totalReadOutTime": {
+      "_instruction": "Enter the total readout time (TRT) as the time interval between acquisition of the first and last k-space lines in the phase-encoding direction during the echo-planar imaging readout.",
       "_embeddedTypes": [
-        "core:QuantitativeValueArray"
-      ],
-      "_instruction": "Enter the direction vector along which phase encoding is applied. This vector indicates the axis of potential distortions in image space (e.g., [1,0,0] for i, [0,1,0] for j, [0,0,1] for k). A negative value indicates reversed polarity."
+        "core:QuantitativeValue"
+      ]
     },
     "repetitionTime": {
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -80,7 +80,7 @@
       ]
     },
     "MTPulseShape": {
-      "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrenquency pulse waveform.",
+      "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrequency (RF) pulse waveform used in this acquisition. This information is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "type": "controlledTerms:PulseShape"
     },
     "numberOfExcitations": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -54,8 +54,16 @@
     "inversionTime": {
       "_embeddedTypes": [
         "core:QuantitativeValue"
-      ],
-      "_instruction": "Enter the inversion time of this aquistion."
+      ]
+    },
+    "matrixSize": {
+      "_instruction": "Enter the matrix size determining the in-plane resolution (frequency x phase x partitions)",
+      "items": {
+        "type": "integer"
+      },
+      "maxItems": 3,
+      "minItems": 2,
+      "type": "array"
     },
     "MRIWeighting": {
       "_instruction": "Add MRI weighting type (e.g.T1Weighting, T2Weighting, R2Weighting, PDWeighting). Note: these terms are not standadized, they merely communicate the image contrast is dominated by the chosen tissue parameter",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -13,7 +13,7 @@
       "type": "integer"
     },
     "diffusionEncodingParameters": {
-      "_instruction": "Enter two files corresponding to b-values and b-vectors parameters used to generate diffusion images.",
+      "_instruction": "Add two diffusion encoding files: a b-value file specifying the diffusion weighting for each acquired volume and a b-vector file specifying the corresponding three-dimensional diffusion gradient directions. Ensure that both files are correctly ordered, that b-vectors are normalized, and that they are aligned with the image volumes.",
       "_linkedTypes": [
         "core:File"
       ],

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -47,13 +47,6 @@
       "_instruction": "Enter the method used for gradient correction",
       "type": "controlledTerms:AnalysisTechnique" 
     },
-    "interSliceGap": {
-      "_embeddedTypes": [
-        "core:QuantitativeValue",
-        "core:QuantitativeValueRange"
-      ],
-      "_instruction": "Enter the inter slice distance of this scan."
-    },
     "inversionTime": {
       "_embeddedTypes": [
         "core:QuantitativeValue"
@@ -92,6 +85,13 @@
         "core:QuantitativeValue"
       ],
       "_instruction": "Enter the echo time of this acquisition (TR)."
+    },
+    "sliceGap": {
+      "_embeddedTypes": [
+        "core:QuantitativeValue",
+        "core:QuantitativeValueRange"
+      ],
+      "_instruction": "Enter the inter slice distance of this scan."
     },
     "sliceTiming": {
       "_instruction": "Enter the time in which each slice have been acquired within each volume, relative to the beginning of the volume acquisition.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -128,7 +128,7 @@
       ]
     },
     "sliceThickness": {
-      "_instruction": "Enter the depth of each slice.",
+      "_instruction": "Enter the slice thickness, defined as the physical thickness of each acquired slice, expressed in millimeters; if uniform, provide a single value, and if variable, provide the corresponding range. This value is specified in the acquisition protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue",
         "core:QuantitativeValueRange"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -100,7 +100,7 @@
       "type": "controlledTerms:MRIparallelAcquisitionTechnique"
     },
     "phaseEncodingDirection": {
-      "_instruction": "Enter the phase encoding direction as a signed unit vector in the scanner or image coordinate system (e.g., [+/-1, 0, 0], [0, +/-1, 0], or [0, 0, +/-1]), where the single nonzero component indicates the x, y, or z axis of phase encoding and the sign indicates the polarity of k-space traversal.",
+      "_instruction": "Enter the phase encoding direction as a signed unit vector in the scanner or image coordinate system (for example, [±1, 0, 0], [0, ±1, 0], or [0, 0, ±1]), where the nonzero component indicates the encoding axis and the sign specifies the polarity of k-space traversal.",
       "items": {
         "type": "integer"
       },

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -65,7 +65,7 @@
       ]
     },
     "matrixSize": {
-      "_instruction": "Enter the matrix size determining the in-plane 2D or 3D resolution (frequency x phase x partitions)",
+      "_instruction": "Enter the matrix size as the number of samples in the frequency and phase encoding directions for two-dimensional acquisitions (frequency × phase), or in the frequency, phase, and partition encoding directions for three-dimensional acquisitions (frequency × phase × partitions). This information is defined by the acquisition protocol and can be retrieved from the DICOM header.",
       "items": {
         "type": "integer"
       },

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -81,7 +81,7 @@
     },
     "numberOfVolumesDiscardedByScanner": {
       "_instruction": "Enter number of volumes discarded by scanner before the first volume.",
-      "type": "number"
+      "type": "integer"
     },
     "parallelAcquisitionTechnique": {
       "_ instruction": "Enter the parallel acquisition technique sequence name for this scan. 'GRAPPA' for most Siemens machines and 'SENSE' for most Philips machines.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -109,7 +109,7 @@
       "type": "array"
     },
     "receiverBandwidth": {
-      "_instruction": "Enter the receive bandwidth corresponding to the range of frequencies per pixel during signal acquisition (Hz/pixel).",
+      "_instruction": "Enter the receiver bandwidth, defined as the range of frequencies sampled per pixel during signal acquisition, expressed in hertz per pixel. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -49,7 +49,7 @@
       ]
     },
     "flipAngle": {
-      "_instruction": "Enter the flip angle of this scan (preferred units: degrees).",
+      "_instruction": "Enter the flip angle, defined as the angle by which the net magnetization is rotated by the radiofrequency excitation pulse, expressed in degrees. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -92,7 +92,7 @@
       "type": "integer"
     },
     "numberOfVolumeDiscarded": {
-      "_instruction": "Enter the number of volumes discarded before the first volume.",
+      "_instruction": "Enter the number of initial volumes automatically discarded by the scanner before saving data, typically to allow signal stabilization at the beginning of the acquisition. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },
     "parallelAcquisitionTechnique": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -63,10 +63,10 @@
       ],
       "_instruction": "Enter the inversion time of this aquistion."
     },
-    "MRSpatialEncoding": {
+    "SpatialEncoding": {
       "_instruction": "Add how spatial information was encoded. Examples include 'frequencyPhaseEncoding' (2D) and 'frequencyPhasePhaseEncoding' (3D).",
       "_linkedTypes": [
-        "controlledTerms:MRSpatialEncoding"
+        "controlledTerms:SpatialEncoding"
       ]
     },
     "MRIWeighting": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -121,7 +121,7 @@
       ]
     },
     "sliceGap": {
-      "_instruction": "Enter the inter slice distance of this scan.",
+      "_instruction": "Enter the slice gap, defined as the distance between adjacent slices, expressed in millimeters and excluding the slice thickness; if slice spacing is uniform, provide a single value, and if it varies across the volume, provide the corresponding range. This information is specified in the acquisition protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue",
         "core:QuantitativeValueRange"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -84,7 +84,7 @@
       "type": "controlledTerms:PulseShape"
     },
     "numberOfExcitations": {
-      "_instruction": "Enter the number of excitation (NEX) which defines how many times each k-space is acquired and averaged. The number varies within a range between 1 and x",
+      "_instruction": "Enter the number of excitations (NEX), defined as the number of times each k-space line is acquired and averaged to improve signal-to-noise ratio; if no averaging was performed, set this value to 1. This value is specified in the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },
     "numberOfSlices": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -63,7 +63,7 @@
       ],
       "_instruction": "Enter the inversion time of this aquistion."
     },
-    "SpatialEncoding": {
+    "spatialEncoding": {
       "_instruction": "Add how spatial information was encoded. Examples include 'frequencyPhaseEncoding' (2D) and 'frequencyPhasePhaseEncoding' (3D).",
       "_linkedTypes": [
         "controlledTerms:SpatialEncoding"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -70,7 +70,7 @@
       "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrenquency pulse waveform.",
       "type": "controlledTerms:PulseShape"
     },
-    "numberOfDiscarded": {
+    "numberOfVolumeDiscarded": {
       "_instruction": "Enter number of volumes discarded before the first volume.",
       "type": "integer"
     },

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -147,7 +147,7 @@
       ]
     },
     "spoilingType": {
-      "_instruction": "Enter the spoiling method used by a spoiled sequence.",
+      "_instruction": "Add the spoiling type used in this acquisition, specifying the method applied to eliminate residual transverse magnetization (for example, radiofrequency spoiling or gradient spoiling). This information is defined in the sequence protocol and can be retrieved from the DICOM header.",
       "_linkedTypes": [
         "controlledTerms:MRISpoilingType"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -64,6 +64,12 @@
         "controlledTerms:MRSpatialEncoding"
       ]
     },
+    "MRIWeighting": {
+      "_instruction": "Add MRI weighting type (e.g.T1Weighting, T2Weighting, R2Weighting, PDWeighting). Note: these terms are not standadized, they merely communicate the image contrast is dominated by the chosen tissue parameter",
+      "_linkedTypes": [
+        "controlledTerms:MRIWeighting"
+      ]
+    },
     "MTPulseShape": {
       "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
       "type": "controlledTerms:MTPulseShape"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -100,9 +100,9 @@
         "core:QuantitativeValueArray"
       ]
     },
-    "spoilingState": {
-      "_instruction": "Boolean stating whether the pulse sequence uses any type of spoiling strategy to suppress residual transverse magnetization.",
-      "type": "boolean"
+    "spoilingType": {
+      "_instruction": "Enter the spoiling method used by a spoiled sequence.",
+      "type": "controlledTerms:SpoilingType"
     },
     "usedCoils": {
       "_instruction": "Add the radiofrequency coils used for this experiment. Corresponds to DICOM tags (0018,9042) [MR Receive Coil Sequence Attribute] and (0018,9049) [MR Transmit Coil Sequence Attribute]. Preferably, create an object describing the coil (e.g., an instance of neuroimaging:MRIRadiofrequencyCoil); if less information is available, provide at least the device type.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -35,6 +35,12 @@
       "type": "array",
       "uniqueItems": true
     },
+    "fatSuppressionTechnique": {
+      "_instruction": "Enter a fat suppression technique used to reduce fat signal (e.g. SPIR, SPAIR, STIR).",
+      "_linkedCategories": [
+        "controlledTerms:MRIFatSuppressionTechnique"
+      ]
+    },
     "fieldOfView": {
       "_instruction": "Add the field of view of this image.",
       "_linkedCategories": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -64,7 +64,7 @@
       ]
     },
     "matrixSize": {
-      "_instruction": "Enter the matrix size determining the in-plane resolution (frequency x phase x partitions)",
+      "_instruction": "Enter the matrix size determining the in-plane 2D or 3D resolution (frequency x phase x partitions)",
       "items": {
         "type": "integer"
       },

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -85,7 +85,7 @@
     },
     "parallelAcquisitionTechnique": {
       "_ instruction": "Enter the parallel acquisition technique sequence name for this scan. 'GRAPPA' for most Siemens machines and 'SENSE' for most Philips machines.",
-      "type": "string"
+      "type": "controlledTerms:parallelAcquisitionTechnique"
     },
     "phaseEncodingDirection": {
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -96,7 +96,7 @@
       "type": "integer"
     },
     "parallelAcquisitionTechnique": {
-      "_ instruction": "Enter the parallel acquisition technique sequence name for this scan. 'GRAPPA' for most Siemens machines and 'SENSE' for most Philips machines.",
+      "_ instruction": "Add the parallel acquisition technique used for this scan (for example, SENSE or GRAPPA). This information is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "type": "controlledTerms:MRIparallelAcquisitionTechnique"
     },
     "phaseEncodingDirection": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -67,6 +67,14 @@
       "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrenquency pulse waveform.",
       "type": "controlledTerms:PulseShape"
     },
+    "numberOfExcitations": {
+      "_instruction": "Enter the number of excitation (NEX) which defines how many times each k-space is acquired and averaged. The number varies within a range between 1 and x",
+      "type": "integer"
+    },
+    "numberOfSlices": {
+      "_instruction": "Enter the number of slices corresponding to the number of image (2D) slices acquired.",
+      "type": "integer"
+    },
     "numberOfVolumeDiscarded": {
       "_instruction": "Enter number of volumes discarded before the first volume.",
       "type": "integer"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -1,6 +1,11 @@
 {
   "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "_type": "neuroimaging:MRIScannerUsage",
+      "required": [
+    "echoTime",
+    "repetitionTime",
+    "sliceTiming"
+  ],
   "properties": {
     "bValues": {
       "_instruction": "Add the b values coresponding to this acquisition.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -64,13 +64,9 @@
         "controlledTerms:MRSpatialEncoding"
       ]
     },
-    "MTState": {
-      "_instruction": "Boolean stating whether the magnetization transfer pulse is applied.",
-      "type": "boolean"
-    },
-    "nonlinearGradientCorrection": {
-      "_instruction": "Has this scan, been corrected for gradient nonlinearities by the scanner sequence?",
-      "type": "boolean"
+    "MTpulseShape": {
+      "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
+      "type": "controlledTerms:MTpulseShape"
     },
     "numberOfVolumesDiscardedByScanner": {
       "_instruction": "Enter number of volumes discarded by scanner before the first volume.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -136,6 +136,12 @@
         "core:QuantitativeValueRange"
       ]
     },
+    "sliceOrientation": {
+      "_instruction": "Add the primary slice plane, defined relative to the scanner coordinate system, where axial corresponds to planes perpendicular to the scanner z-axis, sagittal to planes perpendicular to the x-axis, and coronal to planes perpendicular to the y-axis. This classification is independent of subject orientation and may therefore differ from anatomical planes when the subject is positioned non-standardly in the scanner.",
+      "_linkedTypes": [
+        "controlledTerm:AnatomicalPlane"
+      ]
+    },
     "sliceThickness": {
       "_instruction": "Enter the slice thickness, defined as the physical thickness of each acquired slice, expressed in millimeters; if uniform, provide a single value, and if variable, provide the corresponding range. This value is specified in the acquisition protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -96,12 +96,6 @@
       "minItems": 3,
       "type": "array"
     },
-    "totalReadOutTime": {
-      "_instruction": "Enter the total readout time (TRT) as the time interval between acquisition of the first and last k-space lines in the phase-encoding direction during the echo-planar imaging readout.",
-      "_embeddedTypes": [
-        "core:QuantitativeValue"
-      ]
-    },
     "repetitionTime": {
       "_embeddedTypes": [
         "core:QuantitativeValue"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -21,16 +21,16 @@
       "type" : "array"
     },
     "dwellTime": {
+      "_instruction": "Enter the dwell time of this aquistion.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
-      ],
-      "_instruction": "Enter the dwell time of this aquistion."
+      ]
     },
     "echoTime": {
+      "_instruction": "Enter the echo times of this acquisition (TE).",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ],
-      "_instruction": "Enter the echo times of this acquisition (TE).",
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -42,16 +42,17 @@
       ]
     },
     "flipAngle": {
+      "_instruction": "Enter the flip angle of this scan (preferred units: degrees).",
       "_embeddedTypes": [
         "core:QuantitativeValue"
-      ],
-      "_instruction": "Enter the flip angle of this scan (preferred units: degrees)."
+      ]
     },
     "gradientCorrection": {
       "_instruction": "Enter the method used for gradient correction",
       "type": "controlledTerms:AnalysisTechnique" 
     },
     "inversionTime": {
+      "_instruction": "Enter the inversion time of this aquistion.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]
@@ -84,7 +85,7 @@
       "type": "integer"
     },
     "numberOfVolumeDiscarded": {
-      "_instruction": "Enter number of volumes discarded before the first volume.",
+      "_instruction": "Enter the number of volumes discarded before the first volume.",
       "type": "integer"
     },
     "parallelAcquisitionTechnique": {
@@ -107,10 +108,10 @@
       ]
     },
     "repetitionTime": {
+      "_instruction": "Enter the echo time of this acquisition (TR).",
       "_embeddedTypes": [
         "core:QuantitativeValue"
-      ],
-      "_instruction": "Enter the echo time of this acquisition (TR)."
+      ]
     },
     "sliceGap": {
       "_instruction": "Enter the inter slice distance of this scan.",
@@ -124,8 +125,7 @@
       "_embeddedTypes": [
         "core:QuantitativeValue",
         "core:QuantitativeValueRange"
-      ],
-      "_instruction": "Enter the inter slice distance of this scan."
+      ]
     },
     "sliceTiming": {
       "_instruction": "Enter the time in which each slice have been acquired within each volume, relative to the beginning of the volume acquisition.",
@@ -165,10 +165,10 @@
       ]
     },
     "voxelSize": {
+      "_instruction": "Enter voxel size this image: in this order x,y,z.",
       "_embeddedTypes": [
         "core:QuantitativeValueArray"
-      ],
-      "_instruction": "Enter voxel size this image: in this order x,y,z."
+      ]
     }
   }
 }

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -37,7 +37,7 @@
       "uniqueItems": true
     },
     "fatSuppressionTechnique": {
-      "_instruction": "Enter a fat suppression technique used to reduce fat signal (e.g. SPIR, SPAIR, STIR).",
+      "_instruction": "Add the fat suppression technique used for this acquisition (for example, fat saturation, SPAIR, STIR, or Dixon); if no fat suppression was applied, leave this field null. This information is typically specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_linkedCategories": [
         "controlledTerms:MRIFatSuppressionTechnique"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -75,7 +75,7 @@
         "controlledTerms:MRIWeighting"
       ]
     },
-    "MagnetizationTransferTPulseShape": {
+    "MagnetizationTransferPulseShape": {
       "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
       "type": "controlledTerms:PulseShape"
     },

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -94,12 +94,6 @@
       ],
       "_instruction": "Enter the echo time of this acquisition (TR)."
     },
-    "sliceOrder": {
-      "_instruction": "Enter the time in which each slice have been acquired within each volume.",
-      "_linkedTypes": [
-        "core:QuantitativeValueArray"
-      ]
-    },
     "sliceTiming": {
       "_instruction": "Enter the time in which each slice have been acquired within each volume.",
       "_linkedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -135,7 +135,7 @@
       ]
     },
     "sliceTiming": {
-      "_instruction": "Enter the time in which each slice have been acquired within each volume, relative to the beginning of the volume acquisition.",
+      "_instruction": "Enter the slice timing, defined as the acquisition time of each slice within a volume relative to the start of the volume acquisition. This information is determined by the sequence timing and can be retrieved from the DICOM header.",
       "_linkedTypes": [
         "core:QuantitativeValueArray"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -121,6 +121,12 @@
         "controlledTerms:MRISpoilingType"
       ]
     },
+    "transmitBandwidth": {
+      "_instruction": "Enter the transmit bandwidth corresponding to range of frequencies excited by the radiofrequency pulse to image a specific slice (Hz/pixel).",
+      "_embeddedTypes": [
+        "core:QuantitativeValue"
+      ]
+    },
     "totalReadOutTime": {
       "_instruction": "Enter the total readout time (TRT) as the time interval between acquisition of the first and last k-space lines in the phase-encoding direction during the echo-planar imaging readout.",
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -139,7 +139,7 @@
     "sliceOrientation": {
       "_instruction": "Add the primary slice plane, defined relative to the scanner coordinate system, where axial corresponds to planes perpendicular to the scanner z-axis, sagittal to planes perpendicular to the x-axis, and coronal to planes perpendicular to the y-axis. This classification is independent of subject orientation and may therefore differ from anatomical planes when the subject is positioned non-standardly in the scanner.",
       "_linkedTypes": [
-        "controlledTerm:AnatomicalPlane"
+        "controlledTerms:AnatomicalPlane"
       ]
     },
     "sliceThickness": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -82,12 +82,6 @@
       ],
       "_instruction": "Enter the direction vector along which phase encoding is applied. This vector indicates the axis of potential distortions in image space (e.g., [1,0,0] for i, [0,1,0] for j, [0,0,1] for k). A negative value indicates reversed polarity."
     },
-    "pulseSequenceType": {
-      "_instruction": "Add the type pulse sequence used for this scan.",
-      "_linkedTypes": [
-        "controlledTerms:MRIPulseSequence"
-      ]
-    },
     "repetitionTime": {
       "_embeddedTypes": [
         "core:QuantitativeValue"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -108,7 +108,7 @@
     "spoilingType": {
       "_instruction": "Enter the spoiling method used by a spoiled sequence.",
       "_linkedTypes": [
-        "controlledTerms:SpoilingType"
+        "controlledTerms:MRISpoilingType"
       ]
     },
     "usedCoils": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -74,7 +74,7 @@
       "type": "array"
     },
     "MRIWeighting": {
-      "_instruction": "Add MRI weighting type (e.g.T1Weighting, T2Weighting, R2Weighting, PDWeighting). Note: these terms are not standadized, they merely communicate the image contrast is dominated by the chosen tissue parameter",
+      "_instruction": "Enter the magnetic resonance imaging weighting type describing the dominant source of image contrast. This designation reflects the contrast determined by repetition time, echo time, and inversion time and can be identified from the sequence protocol.",
       "_linkedTypes": [
         "controlledTerms:MRIWeighting"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -172,7 +172,7 @@
       ]
     },
     "voxelSize": {
-      "_instruction": "Enter voxel size this image: in this order x,y,z.",
+      "_instruction": "Enter the voxel size as the physical dimensions of a single image voxel in the x, y, and z directions, expressed in millimeters. This value is typically derived from the field of view, matrix size, and slice thickness and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValueArray"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -8,7 +8,8 @@
   ],
   "properties": {
     "accelerationFactor": {
-      "_instruction": "Enter the acceleration factor (R) corresponding to reduce number of phase-encoding steps, preferably defined between 2 and 6 .",
+      "_instruction": "Enter the acceleration factor (R), defined as the ratio of fully sampled to reduced k-space acquisition, with R ≥ 1 and R = 1 indicating no acceleration. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
+      "minimum": 1,
       "type": "integer"
     },
     "diffusionEncodingParameters": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -84,6 +84,12 @@
       "minItems": 3,
       "type": "array"
     },
+    "receiverBandwidth": {
+      "_instruction": "Enter the receive bandwidth corresponding to the range of frequencies per pixel during signal acquisition (Hz/pixel).",
+      "_embeddedTypes": [
+        "core:QuantitativeValue"
+      ]
+    },
     "repetitionTime": {
       "_embeddedTypes": [
         "core:QuantitativeValue"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -165,7 +165,7 @@
       ]
     },
     "usedCoils": {
-      "_instruction": "Add the radiofrequency coils used for this experiment. Corresponds to DICOM tags (0018,9042) [MR Receive Coil Sequence Attribute] and (0018,9049) [MR Transmit Coil Sequence Attribute]. Preferably, create an object describing the coil (e.g., an instance of neuroimaging:MRIRadiofrequencyCoil); if less information is available, provide at least the device type.",
+      "_instruction": "Add all coils used for this acquisition, including built-in and external transmit, receive, and gradient-related coils, corresponding to the relevant DICOM coil attributes. Preferably provide structured coil descriptions; if unavailable, specify at least the device type.",
       "_linkedTypes": [
         "controlledTerms:DeviceType",
         "neuroimaging:MRICoilUsage"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -85,7 +85,7 @@
     },
     "parallelAcquisitionTechnique": {
       "_ instruction": "Enter the parallel acquisition technique sequence name for this scan. 'GRAPPA' for most Siemens machines and 'SENSE' for most Philips machines.",
-      "type": "controlledTerms:parallelAcquisitionTechnique"
+      "type": "controlledTerms:MRIparallelAcquisitionTechnique"
     },
     "phaseEncodingDirection": {
       "_embeddedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -141,7 +141,7 @@
       ]
     },
     "spatialEncoding": {
-      "_instruction": "Add how spatial information was encoded. Examples include 'frequencyPhaseEncoding' (2D) and 'frequencyPhasePhaseEncoding' (3D).",
+      "_instruction": "Add the spatial encoding scheme used to acquire the data, specifying how frequency, phase, and partition encoding were applied (for example, frequency–phase encoding for two-dimensional acquisitions or frequency–phase–phase encoding for three-dimensional acquisitions). This information is defined in the sequence protocol and can be retrieved from the DICOM header.",
       "_linkedTypes": [
         "controlledTerms:SpatialEncoding"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -79,8 +79,8 @@
       "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrenquency pulse waveform.",
       "type": "controlledTerms:PulseShape"
     },
-    "numberOfVolumesDiscardedByScanner": {
-      "_instruction": "Enter number of volumes discarded by scanner before the first volume.",
+    "numberOfDiscarded": {
+      "_instruction": "Enter number of volumes discarded before the first volume.",
       "type": "integer"
     },
     "parallelAcquisitionTechnique": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -88,7 +88,7 @@
       "type": "integer"
     },
     "numberOfSlices": {
-      "_instruction": "Enter the number of slices corresponding to the number of image (2D) slices acquired.",
+      "_instruction": "Enter the number of slices corresponding to the total number of two-dimensional image slices acquired in this scan. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },
     "numberOfVolumeDiscarded": {

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -91,7 +91,7 @@
       "_instruction": "Enter the number of slices corresponding to the total number of two-dimensional image slices acquired in this scan. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },
-    "numberOfVolumeDiscarded": {
+    "numberOfDiscardedVolumes": {
       "_instruction": "Enter the number of initial volumes automatically discarded by the scanner before saving data, typically to allow signal stabilization at the beginning of the acquisition. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -113,6 +113,14 @@
       "_instruction": "Enter the echo time of this acquisition (TR)."
     },
     "sliceGap": {
+      "_instruction": "Enter the inter slice distance of this scan.",
+      "_embeddedTypes": [
+        "core:QuantitativeValue",
+        "core:QuantitativeValueRange"
+      ]
+    },
+    "sliceThickness": {
+      "_instruction": "Enter the depth of each slice.",
       "_embeddedTypes": [
         "core:QuantitativeValue",
         "core:QuantitativeValueRange"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -107,7 +107,9 @@
     },    
     "spoilingType": {
       "_instruction": "Enter the spoiling method used by a spoiled sequence.",
-      "type": "controlledTerms:SpoilingType"
+      "_linkedTypes": [
+        "controlledTerms:SpoilingType"
+      ]
     },
     "usedCoils": {
       "_instruction": "Add the radiofrequency coils used for this experiment. Corresponds to DICOM tags (0018,9042) [MR Receive Coil Sequence Attribute] and (0018,9049) [MR Transmit Coil Sequence Attribute]. Preferably, create an object describing the coil (e.g., an instance of neuroimaging:MRIRadiofrequencyCoil); if less information is available, provide at least the device type.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -75,8 +75,8 @@
         "controlledTerms:MRIWeighting"
       ]
     },
-    "magnetizationTransferPulseShape": {
-      "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
+    "MTPulseShape": {
+      "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrenquency pulse waveform.",
       "type": "controlledTerms:PulseShape"
     },
     "numberOfVolumesDiscardedByScanner": {
@@ -113,7 +113,7 @@
       "_linkedTypes": [
         "core:QuantitativeValueArray"
       ]
-    },    
+    },
     "spoilingType": {
       "_instruction": "Enter the spoiling method used by a spoiled sequence.",
       "_linkedTypes": [

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -41,7 +41,7 @@
       ],
       "_instruction": "Enter the flip angle of this scan (preferred units: degrees)."
     },
-    "GradientCorrection": {
+    "gradientCorrection": {
       "_instruction": "Enter the method used for gradient correction",
       "type": "controlledTerms:GradientCorrection:" 
     },
@@ -64,9 +64,9 @@
         "controlledTerms:MRSpatialEncoding"
       ]
     },
-    "MTpulseShape": {
+    "MTPulseShape": {
       "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
-      "type": "controlledTerms:MTpulseShape"
+      "type": "controlledTerms:MTPulseShape"
     },
     "numberOfVolumesDiscardedByScanner": {
       "_instruction": "Enter number of volumes discarded by scanner before the first volume.",
@@ -99,7 +99,7 @@
       "_linkedTypes": [
         "core:QuantitativeValueArray"
       ]
-    },
+    },    
     "spoilingType": {
       "_instruction": "Enter the spoiling method used by a spoiled sequence.",
       "type": "controlledTerms:SpoilingType"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -75,9 +75,9 @@
         "controlledTerms:MRIWeighting"
       ]
     },
-    "MTPulseShape": {
+    "MagnetizationTransferTPulseShape": {
       "_instruction": "Enter the shape of the magnetization transfer radiofrenquency pulse waveform.",
-      "type": "controlledTerms:MTPulseShape"
+      "type": "controlledTerms:PulseShape"
     },
     "numberOfVolumesDiscardedByScanner": {
       "_instruction": "Enter number of volumes discarded by scanner before the first volume.",

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -95,7 +95,7 @@
       "_instruction": "Enter the echo time of this acquisition (TR)."
     },
     "sliceTiming": {
-      "_instruction": "Enter the time in which each slice have been acquired within each volume.",
+      "_instruction": "Enter the time in which each slice have been acquired within each volume, relative to the beginning of the volume acquisition.",
       "_linkedTypes": [
         "core:QuantitativeValueArray"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -22,7 +22,7 @@
       "type" : "array"
     },
     "dwellTime": {
-      "_instruction": "Enter the dwell time of this aquistion.",
+      "_instruction": "Enter the dwell time, defined as the time interval between successive data samples during signal readout, which determines the receiver bandwidth and frequency resolution. This value is typically set automatically by the sequence and can be retrieved from the sequence protocol or DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -145,7 +145,7 @@
         "controlledTerms:MRISpoilingType"
       ]
     },
-    "transmitBandwidth": {
+    "transmitterBandwidth": {
       "_instruction": "Enter the transmit bandwidth corresponding to range of frequencies excited by the radiofrequency pulse to image a specific slice (Hz/pixel).",
       "_embeddedTypes": [
         "core:QuantitativeValue"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -59,7 +59,7 @@
       "type": "controlledTerms:AnalysisTechnique" 
     },
     "inversionTime": {
-      "_instruction": "Enter the inversion time of this aquistion.",
+      "_instruction": "Enter the inversion time (TI), defined as the interval between the inversion pulse and the excitation pulse, expressed in milliseconds. This value is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "_embeddedTypes": [
         "core:QuantitativeValue"
       ]

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -14,12 +14,6 @@
         "core:File"
       ]
     },
-    "device": {
-      "_instruction": "Add the MRI Scanner used.",
-      "_linkedTypes": [
-        "neuroimaging:MRIScanner"
-      ]
-    },
     "dwellTime": {
       "_embeddedTypes": [
         "core:QuantitativeValue"

--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -83,16 +83,16 @@
       "_instruction": "Enter the shape of the magnetization transfer (MT) radiofrequency (RF) pulse waveform used in this acquisition. This information is specified in the sequence protocol and can be retrieved from the DICOM header.",
       "type": "controlledTerms:PulseShape"
     },
+    "numberOfDiscardedVolumes": {
+      "_instruction": "Enter the number of initial volumes automatically discarded by the scanner before saving data, typically to allow signal stabilization at the beginning of the acquisition. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
+      "type": "integer"
+    },
     "numberOfExcitations": {
       "_instruction": "Enter the number of excitations (NEX), defined as the number of times each k-space line is acquired and averaged to improve signal-to-noise ratio; if no averaging was performed, set this value to 1. This value is specified in the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },
     "numberOfSlices": {
       "_instruction": "Enter the number of slices corresponding to the total number of two-dimensional image slices acquired in this scan. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
-      "type": "integer"
-    },
-    "numberOfDiscardedVolumes": {
-      "_instruction": "Enter the number of initial volumes automatically discarded by the scanner before saving data, typically to allow signal stabilization at the beginning of the acquisition. This value is defined by the acquisition protocol and can be retrieved from the DICOM header.",
       "type": "integer"
     },
     "parallelAcquisitionTechnique": {


### PR DESCRIPTION
Related issue: https://github.com/openMetadataInitiative/openMINDS_neuroimaging/issues/22

Major changes:
- nonLinearGradientCorrection replaced by GradientCorrection  + linked to controlledTerms to avoid booleans
- MTState replaced by MTPulseShape + linked to controlledTerms to avoid booleans
- SpoilingState replaced by SpoilingType + linked to controlledTerms to avoid booleans
- Removed pulseSequenceType, sliceOrder
- Add MRIWeighting + linked to controlledTerms:MRIWeighting

12/02/2026:
- b-value and b-vectors are removed and gathered in diffusionEncodingParameters property
- numberOfVolumesDiscardedByScanner replaced by numberOfVolumesDiscarded to be less specific
- parallelAcquisitionTechnique linked to controlledTerms:MRIparallelAcquisitionTechnique
- Add totalReadOutTime based on phaseEncodingDirection
- Update phaseEncodingDirection instructions

19/02/2026 - new properties added: 
- fat suppression technique
- matrix size
- number of excitations
- receiver bandwidth
- slice thickness
- transmitter bandwidth