### PR TITLE
Updated version of MRICoilUsage for v5

### DIFF
--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -34,8 +34,8 @@
     },
     "targetAnatomyCoverage": {
       "_instruction": "Add the target anatomy, indicating the primary anatomical structure or region intended to be imaged in this acquisition. This field describes the imaging objective (for example, organ, tissue, or structure) and may be derived from the acquisition protocol description.",
-      "_linkedTypes": [
-        "controlledTerms:ExternalBodyStructure"
+      "_linkedCategories": [
+        "anatomicalLocation"
       ]
     }
   }

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -29,6 +29,12 @@
       "_linkedTypes": [
         "controlledTerms:MRIradioFrequencyCoilRole"
       ]
+    }, 
+    "targetAnatomyCoverage": {
+      "_instruction": "Add the anatomical region(s) the coil is designed to cover.",
+      "_linkedTypes": [
+        "controlledTerms:AnatomicalRegion"
+      ]
     }
   },
   "required": [

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -23,7 +23,7 @@
     "mountingLocation": {
       "_instruction": "Add the anatomical mounting location of the coil, indicating where the coil was positioned on or around the subject (for example, head, neck, knee, or torso). This information is typically applicable to radiofrequency (RF) coils and may be omitted for gradient or shim systems.",
       "_linkedTypes": [
-        "controlledTerms:ExternalBodyStructure"
+        "controlledTerms:ExternalBodyRegion"
       ]
     },
     "signalDirectionality": {

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -2,7 +2,7 @@
   "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "_type": "neuroimaging:MRICoilUsage",
   "required": [
-    "coilRole"
+    "signalDirectionality"
   ],
   "properties": {
     "activeElement": {
@@ -18,7 +18,7 @@
     "signalDirectionality": {
       "_instruction": "Add the functional role of the coil. Examples include 'transmit-only', 'receive-only', 'transmit/receive'(bidirectional).",
       "_linkedTypes": [
-        "controlledTerms:MRICoilRole"
+        "controlledTerms:SignalDirectionality"
       ]
     }, 
     "device": {

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -31,12 +31,6 @@
       "_linkedTypes": [
         "controlledTerms:SignalDirectionality"
       ]
-    },
-    "targetAnatomyCoverage": {
-      "_instruction": "Add the target anatomy, indicating the primary anatomical structure or region intended to be imaged in this acquisition. This field describes the imaging objective (for example, organ, tissue, or structure) and may be derived from the acquisition protocol description.",
-      "_linkedCategories": [
-        "anatomicalLocation"
-      ]
     }
   }
 }

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -16,7 +16,7 @@
       "uniqueItems": true
     },
     "coilRole": {
-      "_instruction": "Add the functional role of the coil (e.g., transmit, receive, transmit/receive).",
+      "_instruction": "Add the functional role of the coil (e.g., transmitting, receiving, transmitting/receiving).",
       "_linkedTypes": [
         "controlledTerms:MRICoilRole"
       ]

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -34,7 +34,7 @@
       ]
     },
     "targetAnatomyCoverage": {
-      "_instruction": "Add the anatomical region(s) the coil is designed to cover.",
+      "_instruction": "Add the target anatomy, indicating the primary anatomical structure or region intended to be imaged in this acquisition. This field describes the imaging objective (for example, organ, tissue, or structure) and may be derived from the acquisition protocol description.",
       "_linkedTypes": [
         "controlledTerms:ExternalBodyStructure"
       ]

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -28,7 +28,7 @@
       ]
     },
     "mountingLocation": {
-      "_instruction": "Describe how the coil is mounted or positioned relative to the subject (e.g., head, knee, body).",
+      "_instruction": "Add the position of the coil relative to the subject's anatomy (e.g., head, knee, body).",
       "_linkedTypes": [
         "controlledTerms:AnatomicalRegion"
       ]

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -6,7 +6,7 @@
   ],
   "properties": {
     "activeElement": {
-      "_instruction": "If applicable, list the identifiers of the active coil elements or channels.",
+      "_instruction": "Only applicable to radiofrequency (RF) coils! Enter the active coil element identifier(s) corresponding to the transmitting and/or receiving elements that were electrically active during this acquisition; the number of identifiers typically matches the number of physical elements in the selected RF coil and may be fewer if some elements were disabled.",
       "_linkedTypes": [
         "core:GenericIdentifier",
         "string"

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -1,8 +1,8 @@
 {
   "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "_type": "neuroimaging:MRICoilUsage",
-    "required": [
-    "radioFrequencyCoilRole"
+  "required": [
+    "coilRole"
   ],
   "properties": {
     "activeElement": {
@@ -15,6 +15,12 @@
       "type": "array",
       "uniqueItems": true
     },
+    "coilRole": {
+      "_instruction": "Add the functional role of the coil (e.g., transmit, receive, transmit/receive).",
+      "_linkedTypes": [
+        "controlledTerms:MRICoilRole"
+      ]
+    }, 
     "device": {
       "_instruction": "Add the MRI Coil used.",
       "_linkedTypes": [
@@ -27,12 +33,6 @@
         "controlledTerms:AnatomicalRegion"
       ]
     },
-    "radiofrequencyCoilRole": {
-      "_instruction": "Add the functional role of the RF coil (e.g., transmit, receive, transmit/receive).",
-      "_linkedTypes": [
-        "controlledTerms:MRIradioFrequencyCoilRole"
-      ]
-    }, 
     "targetAnatomyCoverage": {
       "_instruction": "Add the anatomical region(s) the coil is designed to cover.",
       "_linkedTypes": [

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -7,10 +7,9 @@
   "properties": {
     "activeElement": {
       "_instruction": "Only applicable to radiofrequency (RF) coils! Enter the active coil element identifier(s) corresponding to the transmitting and/or receiving elements that were electrically active during this acquisition; the number of identifiers typically matches the number of physical elements in the selected RF coil and may be fewer if some elements were disabled.",
-      "_linkedTypes": [
-        "core:GenericIdentifier",
-        "string"
-      ],
+      "items": {
+        "type": "string"
+      },
       "minItems": 1,
       "type": "array",
       "uniqueItems": true

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -1,6 +1,9 @@
 {
   "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "_type": "neuroimaging:MRICoilUsage",
+    "required": [
+    "radioFrequencyCoilRole"
+  ],
   "properties": {
     "activeElement": {
       "_instruction": "If applicable, list the identifiers of the active coil elements or channels.",
@@ -36,8 +39,5 @@
         "controlledTerms:AnatomicalRegion"
       ]
     }
-  },
-  "required": [
-    "radioFrequencyCoilRole"
-  ]
+  }
 }

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -24,7 +24,7 @@
     "mountingLocation": {
       "_instruction": "Add the position of the coil relative to the subject's anatomy (e.g., head, knee, body).",
       "_linkedTypes": [
-        "controlledTerms:AnatomicalRegion"
+        "controlledTerms:ExternalBodyStructure"
       ]
     },
     "signalDirectionality": {
@@ -36,7 +36,7 @@
     "targetAnatomyCoverage": {
       "_instruction": "Add the anatomical region(s) the coil is designed to cover.",
       "_linkedTypes": [
-        "controlledTerms:AnatomicalRegion"
+        "controlledTerms:ExternalBodyStructure"
       ]
     }
   }

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -15,8 +15,8 @@
       "type": "array",
       "uniqueItems": true
     },
-    "coilRole": {
-      "_instruction": "Add the functional role of the coil (e.g., transmitting, receiving, transmitting/receiving).",
+    "signalDirectionality": {
+      "_instruction": "Add the functional role of the coil. Examples include 'transmit-only', 'receive-only', 'transmit/receive'(bidirectional).",
       "_linkedTypes": [
         "controlledTerms:MRICoilRole"
       ]

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -15,12 +15,6 @@
       "type": "array",
       "uniqueItems": true
     },
-    "signalDirectionality": {
-      "_instruction": "Add the functional role of the coil. Examples include 'transmit-only', 'receive-only', 'transmit/receive'(bidirectional).",
-      "_linkedTypes": [
-        "controlledTerms:SignalDirectionality"
-      ]
-    }, 
     "device": {
       "_instruction": "Add the MRI Coil used.",
       "_linkedTypes": [
@@ -31,6 +25,12 @@
       "_instruction": "Add the position of the coil relative to the subject's anatomy (e.g., head, knee, body).",
       "_linkedTypes": [
         "controlledTerms:AnatomicalRegion"
+      ]
+    },
+    "signalDirectionality": {
+      "_instruction": "Add the signal directionality corresponding to the functional role of the coil. Examples include 'transmit-only', 'receive-only', 'transmit/receive'(bidirectional).",
+      "_linkedTypes": [
+        "controlledTerms:SignalDirectionality"
       ]
     },
     "targetAnatomyCoverage": {

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -22,7 +22,7 @@
       ]
     },
     "mountingLocation": {
-      "_instruction": "Add the position of the coil relative to the subject's anatomy (e.g., head, knee, body).",
+      "_instruction": "Add the anatomical mounting location of the coil, indicating where the coil was positioned on or around the subject (for example, head, neck, knee, or torso). This information is typically applicable to radiofrequency (RF) coils and may be omitted for gradient or shim systems.",
       "_linkedTypes": [
         "controlledTerms:ExternalBodyStructure"
       ]

--- a/schemas/device/MRICoilUsage.schema.tpl.json
+++ b/schemas/device/MRICoilUsage.schema.tpl.json
@@ -28,7 +28,7 @@
       ]
     },
     "signalDirectionality": {
-      "_instruction": "Add the signal directionality corresponding to the functional role of the coil. Examples include 'transmit-only', 'receive-only', 'transmit/receive'(bidirectional).",
+      "_instruction": "Add the signal directionality of the coil, indicating whether it was used for signal transmission, reception, or both. This information is typically defined in the system configuration and can be retrieved from the DICOM header or scanner hardware metadata.",
       "_linkedTypes": [
         "controlledTerms:SignalDirectionality"
       ]


### PR DESCRIPTION
Major changes: 
- coilRole property is required 
- radioFrequencyCoilRole is replaced by coilRole

19/02/2026
-    rename radiofrequencyCoilRole to signalDirectionality 