### PR TITLE
Add device field for MRI Scanner in schema

### DIFF
--- a/schemas/device/MRIScannerUsage.schema.tpl.json
+++ b/schemas/device/MRIScannerUsage.schema.tpl.json
@@ -12,6 +12,12 @@
       "minimum": 1,
       "type": "integer"
     },
+    "device": {
+      "_instruction": "Add the MRI Scanner used.",
+      "_linkedTypes": [
+        "neuroimaging:MRIScanner"
+      ]
+    },
     "diffusionEncodingParameters": {
       "_instruction": "Add two diffusion encoding files: a b-value file specifying the diffusion weighting for each acquired volume and a b-vector file specifying the corresponding three-dimensional diffusion gradient directions. Ensure that both files are correctly ordered, that b-vectors are normalized, and that they are aligned with the image volumes.",
       "_linkedTypes": [


### PR DESCRIPTION
is set required already in the concept schema but needs to be specified in the extended schemas
@apdavison should we still merge this into the v5.0 ? otherwise this would then be v5.1

fixes https://github.com/openMetadataInitiative/openMINDS_documentation/issues/69